### PR TITLE
add image serving through base directory in development. change image…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ db.sqlite3
 __pycache__
 venv
 
-server/images
+server/uploads

--- a/server/core/settings.py
+++ b/server/core/settings.py
@@ -187,3 +187,6 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
 ]
 
 CSRF_TRUSTED_ORIGINS = ['https://*.gitpod.io']
+
+MEDIA_URL = '/uploads/'
+MEDIA_ROOT = os.path.join(BASE_DIR, 'uploads')

--- a/server/core/urls.py
+++ b/server/core/urls.py
@@ -17,6 +17,8 @@ from django.contrib import admin
 from django.urls import path
 from receipts import views
 from django.conf.urls import include
+from django.conf.urls.static import static
+from django.conf import settings
 from django.views.generic.base import RedirectView
 
 urlpatterns = [
@@ -28,3 +30,7 @@ urlpatterns = [
 urlpatterns += [
     path('api/direct-auth/', include('rest_framework.urls')),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL,
+                          document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Quick update to allow for image serving from our backend. Should not require a new migration if you've already migrated from my previous PR. Make sure to install packages using ```pip install -r requirements.txt``` after activating your virtual environment.

Any images uploaded to the db after this update can be accessed by navigating to the url provided in the receipt_image field. images are uploaded and stored in server/uploads/images. You may have a server/images folder from our previous setup - you can delete this folder as images are now being stored in server/uploads/images.