### PR TITLE
Auth integration and graphql updates

### DIFF
--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -23,7 +23,6 @@ export const AuthContext = createContext<AuthContext>({
   setUserToken: () => {},
 });
 
-
 const lightTheme = createTheme({
   components: {
     MuiContainer: {

--- a/server/core/settings.py
+++ b/server/core/settings.py
@@ -64,8 +64,6 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
 ]
 
-JWT_AUTH_COOKIE = 'jwt_auth_cookie'
-
 ROOT_URLCONF = 'core.urls'
 
 TEMPLATES = [
@@ -113,6 +111,9 @@ cloudinary.config(
 
 GRAPHENE = {
     'SCHEMA': 'receipts.graphql.schema.schema',
+    'MIDDLEWARE': [
+        'graphql_jwt.middleware.JSONWebTokenMiddleware',
+    ],
 }
 
 # Authentication
@@ -121,6 +122,8 @@ GRAPHQL_JWT = {
     'JWT_SECRET_KEY': os.getenv('JWT_SECRET_KEY'),
     'JWT_EXPIRATION_DELTA': datetime.timedelta(seconds=10800),
 }
+
+SESSION_COOKIE_AGE = 1800
 
 AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',

--- a/server/core/settings.py
+++ b/server/core/settings.py
@@ -52,26 +52,6 @@ INSTALLED_APPS = [
     'cloudinary'
 ]
 
-AUTH_USER_MODEL = 'receipts.ExtendedUser'
-
-
-GRAPHENE = {
-    'SCHEMA': 'receipts.graphql.schema.schema',
-    'MIDDLEWARE': [
-        'graphql_jwt.middleware.JSONWebTokenMiddleware',
-    ],
-}
-
-GRAPHQL_JWT = {
-    'JWT_SECRET_KEY': os.getenv('JWT_SECRET_KEY'),
-    'JWT_EXPIRATION_DELTA': datetime.timedelta(seconds=10800),
-}
-
-AUTHENTICATION_BACKENDS = [
-    'django.contrib.auth.backends.ModelBackend',
-    'graphql_jwt.backends.JSONWebTokenBackend',
-]
-
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
@@ -82,7 +62,6 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'graphql_jwt.decorators.jwt_cookie',
 ]
 
 JWT_AUTH_COOKIE = 'jwt_auth_cookie'
@@ -134,9 +113,6 @@ cloudinary.config(
 
 GRAPHENE = {
     'SCHEMA': 'receipts.graphql.schema.schema',
-    'MIDDLEWARE': [
-        'graphql_jwt.middleware.JSONWebTokenMiddleware',
-    ],
 }
 
 # Authentication
@@ -148,7 +124,6 @@ GRAPHQL_JWT = {
 
 AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
-    'graphql_jwt.backends.JSONWebTokenBackend',
 ]
 
 # Password validation
@@ -167,9 +142,6 @@ AUTH_PASSWORD_VALIDATORS = [
     {
         'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
     },
-    # {
-    #     'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
-    # },
     {
         'NAME': 'django_advanced_password_validation.advanced_password_validation.ContainsDigitsValidator',
         'OPTIONS': {

--- a/server/receipts/graphql/decorators.py
+++ b/server/receipts/graphql/decorators.py
@@ -1,0 +1,66 @@
+from ..models import Receipt, Tag
+from django.contrib.auth import get_user_model
+
+import jwt as pyjwt
+from django.conf import settings
+
+import re
+from graphql.error import GraphQLError
+
+
+
+def login_required(func):
+    def wrapper(root, info, *args, **kwargs):
+        authorization_header = info.context.headers.get('Authorization', None)
+        if authorization_header is None:
+            raise GraphQLError('Authentication token is required')
+        
+        pattern = re.compile("^Bearer\s(.+)$")
+        match = pattern.match(authorization_header)
+        if not match:
+            raise GraphQLError("Invalid Authorization token format")
+        
+        token = authorization_header.split()[1]
+
+        try:
+            payload = pyjwt.decode(
+                token,
+                settings.GRAPHQL_JWT["JWT_SECRET_KEY"],
+                algorithms=['HS256']
+            )
+
+            kwargs['user_id'] = payload.get('user_id')
+        except pyjwt.ExpiredSignatureError:
+            raise GraphQLError('Token has expired')
+        except pyjwt.InvalidTokenError:
+            raise GraphQLError('Invalid token')
+
+        return func(root, info, *args, **kwargs)
+
+    return wrapper
+
+
+def is_receipt_owner_or_superuser(func):
+    def wrapper(root, info, *args, **kwargs):
+        user_id = kwargs.get('user_id')
+        receipt_id = kwargs.get('receipt_id')
+
+        try:
+            receipt_instance = Receipt.objects.get(pk=receipt_id)
+        except Receipt.DoesNotExist:
+            raise GraphQLError(
+                f'Receipt with id: {receipt_id} does not exist.'
+            )
+        
+        print(
+            f'user_id: {user_id}, receipt user_id: {receipt_instance.user.id}, superuser: {info.context.user.is_superuser}')
+        
+        if str(receipt_instance.user.id) == str(user_id) or info.context.user.is_superuser:
+            kwargs['receipt_instance'] = receipt_instance
+            return func(root, info, *args, **kwargs)
+        else:
+            raise GraphQLError(
+                'You do not have permission to perform this action'
+            )
+
+    return wrapper

--- a/server/receipts/graphql/schema.py
+++ b/server/receipts/graphql/schema.py
@@ -40,6 +40,8 @@ def login_required(func):
                 settings.GRAPHQL_JWT["JWT_SECRET_KEY"], 
                 algorithms=['HS256']
             )
+
+            kwargs['payload'] = payload
         except pyjwt.ExpiredSignatureError:
             raise GraphQLError('Token has expired')
         except pyjwt.InvalidTokenError:
@@ -66,7 +68,6 @@ class LoginMutation(graphene.Mutation):
             return None
 
         user = authenticate(email=email, password=password)
-        # print("User:", user)
 
         if user is not None and user.is_active:
             # Login the user to create a session
@@ -79,7 +80,7 @@ class LoginMutation(graphene.Mutation):
 
             return LoginMutation(success=True, token=token)
         else:
-            return LoginMutation(success=False, token=None, response=None)
+            return LoginMutation(success=False, token=None)
 
 
 class LogoutMutation(graphene.Mutation):

--- a/server/receipts/models.py
+++ b/server/receipts/models.py
@@ -12,6 +12,7 @@ class ExtendedUser(AbstractUser):
     USERNAME_FIELD = 'email'
     REQUIRED_FIELDS = ['username', 'password']
 
+
 class Receipt(models.Model):
     store_name = models.CharField(
         max_length=255,


### PR DESCRIPTION
This PR integrates authentication with our GraphQl API. The logic of the user queries and mutations have also been updated. Here are the changes:

**Authentication and API Protection**
- The Login mutation now returns an 'Invalid Credentials' error when the user enters invalid credentials.
- Added a new file: decorators.py to the graphql folder which contains decorators that can be applied to queries/mutations
- The login_required decorator has been moved to decorators.py and has updated logic. It now checks both the user session ID in the session cookie that Django places in the headers through the login mutation, and the JWT that the client provides in the Authorization header for validity. Note that the session cookie does not need to be manually provided by the client, it will be passed automatically between the client and server until destroyed by the logout mutation.
- Added additional error catching for when a user does not have an active session ID (in the case of having a valid JWT, but not having gone through the login mutation), when the user that the JWT is signed for has been deleted (in this case, the token is still valid, but the user is no longer in the database), and when there is either no Authorization header or the JWT is passed in the incorrect format.
- The login_required decorator, which most of our user and receipt queries/mutations now use (the createUser mutation is the only mutation that does not require a logged-in user for obvious reasons), requires that the JWT be passed in the headers on each request in the following format:
```
{
      "Authorization": "Bearer <token>"
}
```
- The logout mutation must be used to log out the user correctly.
- Added an is_owner_or_superuser decorator that allows only a superuser or owner of a record to perform the requested action.
- Added an is_superuser decorator that allows only a superuser to perform a requested action.

**Users**
- All user queries and mutations, except for the createUser mutation, now require a user to be logged in to access them.
- All user queries and mutations, except for the getUser query, no longer require manual input of a user id.
- Added a getUser query that has the same functionality as the former user query, which queries a user based on an id, email, or both. You must be a superuser to utilize this query.
- The allUsers query requires the user to be a superuser.
- All queries and mutations, except for the getUser and allUsers query, will automatically perform their actions based on the user that is currently logged in. For instance, accessing the user query returns user data for the logged-in user. Similarly, the updateUser mutation updates the credentials for the logged-in user.

**Receipts**
- Added a totalExpenditureByDate query that will return the sum total cost of all receipts that have a date within the date range provided through the dateGte (date greater than or equal to) and dateLte (date less than or equal to) arguments.
- All receipt queries and mutations require a user to be logged in to access them.
- All Receipt queries and mutations, except for the allReceipts query, no longer require a user id to be passed in manually.
- The allReceipts query requires the user to be a superuser. You can also pass in a user id to this query to retrieve all receipts by that user. If no id is provided, it returns all receipts.
- The receipt query, updateReceipt mutation, and deleteReceipt mutation requires the user to be a superuser or to be the owner of the receipt
- The allReceiptsByUser, filteredReceipts, and totalExpenditureByDate queries automatically return only receipts created by the logged-in user.

